### PR TITLE
Melhoria nos testes unitários do componente Header

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "axios-mock-adapter": "^1.19.0",
     "json-server": "^0.16.3"
   },
+  "jest": {
+    "resetMocks": false
+  },
   "eslintConfig": {
     "extends": [
       "react-app"

--- a/src/__tests__/components/Header.spec.tsx
+++ b/src/__tests__/components/Header.spec.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
 import { ReactNode } from 'react';
 import Header from '../../components/Header';
+import { useCart } from '../../hooks/useCart';
 
 jest.mock('react-router-dom', () => {
   return {
@@ -10,7 +11,7 @@ jest.mock('react-router-dom', () => {
 
 jest.mock('../../hooks/useCart', () => {
   return {
-    useCart: () => ({
+    useCart: jest.fn(() => ({
       cart: [
         {
           amount: 2,
@@ -29,15 +30,44 @@ jest.mock('../../hooks/useCart', () => {
           title: 'Tênis VR Caminhada Confortável Detalhes Couro Masculino',
         },
       ],
-    }),
+    })),
   };
 });
 
+const useCartMock = useCart as jest.Mock;
+
 describe('Header Component', () => {
   it('should be able to render the amount of products added to cart', () => {
-    const { getByTestId } = render(<Header />);
+    const { getByLabelText } = render(<Header />);
 
-    const cartSizeCounter = getByTestId('cart-size');
+    const cartSizeCounter = getByLabelText('cart-size');
     expect(cartSizeCounter).toHaveTextContent('2 itens');
+  });
+
+  it('should be able to render no data message when cart is empty', () => {
+    useCartMock.mockImplementation(() => ({ cart: [] }));
+
+    const { getByLabelText } = render(<Header />);
+
+    const cartSizeCounter = getByLabelText('cart-size');
+    expect(cartSizeCounter).toHaveTextContent('Sem itens');
+  });
+
+  it('should be able to render cart message when it has just one item', () => {
+    useCartMock.mockImplementation(() => ({
+      cart: [{
+        amount: 2,
+        id: 1,
+        image:
+          'https://rocketseat-cdn.s3-sa-east-1.amazonaws.com/modulo-redux/tenis1.jpg',
+        price: 179.9,
+        title: 'Tênis de Caminhada Leve Confortável',
+      },]
+    }));
+
+    const { getByLabelText } = render(<Header />);
+
+    const cartSizeCounter = getByLabelText('cart-size');
+    expect(cartSizeCounter).toHaveTextContent('1 item');
   });
 });

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -7,8 +7,14 @@ import { Container, Cart } from './styles';
 import { useCart } from '../../hooks/useCart';
 
 const Header = (): JSX.Element => {
-  // const { cart } = useCart();
-  // const cartSize = // TODO;
+  const { cart } = useCart();
+  const cartSize = cart.length;
+
+  function cartSizeMessage() {
+    if (cartSize === 0) return 'Sem itens';
+    if (cartSize === 1) return '1 item';
+    return `${cartSize} itens`;
+  }
 
   return (
     <Container>
@@ -19,8 +25,8 @@ const Header = (): JSX.Element => {
       <Cart to="/cart">
         <div>
           <strong>Meu carrinho</strong>
-          <span data-testid="cart-size">
-            {/* {cartSize === 1 ? `${cartSize} item` : `${cartSize} itens`} */}
+          <span aria-label="cart-size">
+            {cartSizeMessage()}
           </span>
         </div>
         <MdShoppingBasket size={36} color="#FFF" />


### PR DESCRIPTION
Adição de uma tratativa para casos onde o carrinho esteja vazinho, com apenas um item, ou mais de um item.
Alteração na query para buscar o texto no componente de `data-testid` para `aria-label`, mais indicado para acessibilidade.